### PR TITLE
Enabling the trace option to debug the bedrock

### DIFF
--- a/src/services/helper/summarizetext.js
+++ b/src/services/helper/summarizetext.js
@@ -129,7 +129,8 @@ async function processWithBedrockAndWriteToS3(requestId, prompt) {
       messages: [{ role: 'user', content: prompt }]
     }),
     guardrailIdentifier: 'arn:aws:bedrock:eu-west-2:332499610595:guardrail/eqs44398uvjn',
-    guardrailVersion: '1'
+    guardrailVersion: '1',
+    trace: 'ENABLED'
   }
 
   try {


### PR DESCRIPTION
Enabling the trace option to debug the bedrock